### PR TITLE
add limit operator reference implementation

### DIFF
--- a/sandbox/prototype/common/src/main/java/org/apache/drill/common/logical/data/LogicalOperator.java
+++ b/sandbox/prototype/common/src/main/java/org/apache/drill/common/logical/data/LogicalOperator.java
@@ -33,7 +33,7 @@ import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property="op")
 public interface LogicalOperator extends Iterable<LogicalOperator>{
 	
-	public static final Class<?>[] SUB_TYPES = {Write.class, Aggregate.class, Group.class, Filter.class, Flatten.class, Join.class, Order.class, Project.class, Scan.class, Sequence.class, Transform.class, Union.class, WindowFrame.class};
+	public static final Class<?>[] SUB_TYPES = {Write.class, Aggregate.class, Group.class, Filter.class, Flatten.class, Join.class, Order.class, Limit.class, Project.class, Scan.class, Sequence.class, Transform.class, Union.class, WindowFrame.class};
 	
 	public void accept(OpVisitor visitor);
 	public void registerAsSubscriber(LogicalOperator operator);

--- a/sandbox/prototype/exec/ref/src/main/java/org/apache/drill/exec/ref/rops/LimitROP.java
+++ b/sandbox/prototype/exec/ref/src/main/java/org/apache/drill/exec/ref/rops/LimitROP.java
@@ -1,0 +1,87 @@
+/*******************************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+package org.apache.drill.exec.ref.rops;
+
+import org.apache.drill.common.logical.data.Limit;
+import org.apache.drill.exec.ref.RecordIterator;
+import org.apache.drill.exec.ref.RecordPointer;
+import org.apache.drill.exec.ref.eval.EvaluatorFactory;
+
+public class LimitROP extends SingleInputROPBase<Limit>{
+
+  private LimitIterator iter;
+  private int first;
+  private int last;
+
+  public LimitROP(Limit config) {
+    super(config);
+  }
+
+  @Override
+  protected void setupEvals(EvaluatorFactory builder) {
+    first = config.getFirst();
+    last = config.getLast();
+  }
+
+  @Override
+  public void setInput(RecordIterator incoming) {
+    iter = new LimitIterator(incoming);
+  }
+
+  @Override
+  public RecordIterator getIteratorInternal() {
+    return iter;
+  }
+  
+  private class LimitIterator implements RecordIterator{
+    RecordIterator incoming;
+    int currentIndex = 0;
+
+    public LimitIterator(RecordIterator incoming) {
+      this.incoming = incoming;
+    }
+
+    @Override
+    public NextOutcome next() {
+      NextOutcome r;
+      while(true){
+        r = incoming.next();
+        currentIndex++;
+        if (currentIndex > first && currentIndex <= last)
+            return r;
+
+        if (currentIndex > last)
+            return NextOutcome.NONE_LEFT;
+      }
+    }
+
+    @Override
+    public ROP getParent() {
+      return LimitROP.this;
+    }
+
+    @Override
+    public RecordPointer getRecordPointer() {
+      return record;
+    }
+    
+    
+    
+  }
+  
+}

--- a/sandbox/prototype/exec/ref/src/test/resources/simple_plan.json
+++ b/sandbox/prototype/exec/ref/src/test/resources/simple_plan.json
@@ -64,7 +64,12 @@
 	      projections: [
 	        { ref: "output", expr: "donuts" }
 	      ]
-	    },	    
+	    },
+	    {
+          op: "limit",
+          first: 0,
+          last: 2
+        },
 	    {
 	      op: "write",
 	      memo: "save file",


### PR DESCRIPTION
Basic implementation of the Limit operator.  1-indexed such that a limit with {last = 0} always returns nothing, and {last = 1} returns the first object - I chose this because it made sense to me.  

Doesn't do any validation on the values of first and last. 

This is my first time digging around this codebase, feedback is very much appreciated.
